### PR TITLE
fix: update stale state in reducer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,8 @@ export function useZustand<State, Slice>(
   const state = store.getState();
   const [[sliceFromReducer, storeFromReducer], rerender] = useReducer<
     Reducer<
-      readonly [Slice, StoreApi<State>, State],
-      readonly [Slice, StoreApi<State>, State] | undefined
+      [Slice, StoreApi<State>, State],
+      [Slice, StoreApi<State>, State] | undefined
     >,
     undefined
   >(
@@ -25,6 +25,7 @@ export function useZustand<State, Slice>(
       }
       const nextSlice = selector(nextState);
       if (areEqual(prev[0], nextSlice) && prev[1] === store) {
+        prev[2] = nextState;
         return prev;
       }
       return [nextSlice, store, nextState];


### PR DESCRIPTION
Similar to https://github.com/facebook/react/pull/25968

The reducer is used for memoization, not managing state. So I think it's ok to mutate the tuple, since the reducer is already not a pure function.